### PR TITLE
Fix the z-index of the debug-bar content.

### DIFF
--- a/tgext/debugbar/statics/style.css
+++ b/tgext/debugbar/statics/style.css
@@ -25,6 +25,7 @@
 	position: fixed;
 	background-color: rgba(0, 0, 0, 0.6);
 	color: #D3D3D3;
+	z-index: 998;
 }
 
 #tgdb_debugbar .tgdb_section {


### PR DESCRIPTION
This helps on sites with a top menu bar with a z-index of its own (but lower that 998).
