### PR TITLE
Replace register_hook obsoleted by TG 2.3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='tgext.debugbar',
       package_data = {'': ['*.html', '*.js', '*.css', '*.png', '*.gif']},
       zip_safe=False,
       install_requires=[
-        "TurboGears2 >= 2.2.0",
+        "TurboGears2 >= 2.3.5",
         "Pygments",
         "Genshi"
       ],


### PR DESCRIPTION
tgext.debugbar doesn't work with newer versions of TurboGears. Here's my humble attempt to make this amazing plugin work again.

