### PR TITLE
Use sqlalchemy customised serializers

### DIFF
--- a/tgext/debugbar/sections/sqla.py
+++ b/tgext/debugbar/sections/sqla.py
@@ -69,9 +69,6 @@ except ImportError:
 
 def enable_sqlalchemy(*args, **kw):
     if has_sqla:
-        if "sqlalchemy.json_serializer" in config:
-            json_encoder = config["sqlalchemy.json_serializer"]
-
         event.listen(Engine, "before_cursor_execute", _before_cursor_execute)
         event.listen(Engine, "after_cursor_execute", _after_cursor_execute)
 
@@ -92,6 +89,9 @@ class SQLADebugSection(DebugSection):
         return _('SQLAlchemy')
 
     def _gather_queries(self):
+        if "sqlalchemy.json_serializer" in config:
+            json_encoder = config["sqlalchemy.json_serializer"]
+
         queries = getattr(request, 'tgdb_sqla_queries', [])
         if not queries:
             return []

--- a/tgext/debugbar/sections/sqla.py
+++ b/tgext/debugbar/sections/sqla.py
@@ -69,6 +69,9 @@ except ImportError:
 
 def enable_sqlalchemy(*args, **kw):
     if has_sqla:
+        if "sqlalchemy.json_serializer" in config:
+            json_encoder = config["sqlalchemy.json_serializer"]
+
         event.listen(Engine, "before_cursor_execute", _before_cursor_execute)
         event.listen(Engine, "after_cursor_execute", _after_cursor_execute)
 
@@ -89,9 +92,6 @@ class SQLADebugSection(DebugSection):
         return _('SQLAlchemy')
 
     def _gather_queries(self):
-        if "sqlalchemy.json_serializer" in config:
-            json_encoder = config["sqlalchemy.json_serializer"]
-
         queries = getattr(request, 'tgdb_sqla_queries', [])
         if not queries:
             return []

--- a/tgext/debugbar/sections/sqla.py
+++ b/tgext/debugbar/sections/sqla.py
@@ -6,6 +6,7 @@ import weakref
 import logging
 import datetime
 
+from tg import config
 from tg._compat import unicode_text
 
 try:
@@ -19,7 +20,7 @@ class ExtendedJSONEncoder(json.JSONEncoder):
             return str(obj)
         else:
             return json.JSONEncoder.default(self, obj)
-json_encoder = ExtendedJSONEncoder()
+json_encoder = ExtendedJSONEncoder() if "sqlalchemy.json_serializer" not in config else config["sqlalchemy.json_serializer"]
 
 import tg
 from tg import config, request, app_globals


### PR DESCRIPTION
This makes tgext.debugbar use customised sqlalchemy json serializers if they are defined in the config.

Fixes #5 

Note: I'm not 100% happy with where json_encoder is reading from the config, but that's the place where it worked for me (is_active, enable_sqlalchemy and directly on the original json_encoder definition didn't work with the tg2 app I'm using).